### PR TITLE
Replace one - with _ in 'Illegal workspace name' error message

### DIFF
--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -160,7 +160,7 @@ void commandline(po::variables_map &opt, string &name, int &duration, string &fi
     // validate workspace name against nasty characters    
     static const boost::regex e("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$");
     if (!regex_match(name, e)) {
-            cerr << "Error: Illegal workspace name, use characters and numbers, -,. and - only!" << endl;
+            cerr << "Error: Illegal workspace name, use characters and numbers, -,. and _ only!" << endl;
             exit(1);
     }
 }

--- a/src/ws_release.cpp
+++ b/src/ws_release.cpp
@@ -109,7 +109,7 @@ void commandline(po::variables_map &opt, string &name, int &duration,
     // validate workspace name against nasty characters    
     static const boost::regex e("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$");
     if (!regex_match(name, e)) {
-            cerr << "Error: Illegal workspace name, use characters and numbers, -,. and - only!" << endl;
+            cerr << "Error: Illegal workspace name, use characters and numbers, -,. and _ only!" << endl;
             exit(1);
     }
 }

--- a/src/ws_restore.cpp
+++ b/src/ws_restore.cpp
@@ -128,7 +128,7 @@ void commandline(po::variables_map &opt, string &name, string &target,
         // validate workspace name against nasty characters    
         static const boost::regex e("^[a-zA-Z0-9][a-zA-Z0-9_.-]*$");
         if (!regex_match(name, e)) {
-            cerr << "Error: Illegal workspace name, use characters and numbers, -,. and - only!" << endl;
+            cerr << "Error: Illegal workspace name, use characters and numbers, -,. and _ only!" << endl;
             exit(1);
         }
     } else if (!opt.count("list")) {

--- a/testing/tests/06-parameters/err1.ref
+++ b/testing/tests/06-parameters/err1.ref
@@ -1,1 +1,1 @@
-Error: Illegal workspace name, use characters and numbers, -,. and - only!
+Error: Illegal workspace name, use characters and numbers, -,. and _ only!


### PR DESCRIPTION
Error message currently reads
> Error: Illegal workspace name, use characters and numbers, -,. and - only!

From the regular expression used I suppose that one of the dashes ( - ) should be an underscore ( _ ).
This pull request changes the error message to
> Error: Illegal workspace name, use characters and numbers, -,. and _ only!
