### PR TITLE
Error on ws not found

### DIFF
--- a/bin/ws_find
+++ b/bin/ws_find
@@ -144,3 +144,5 @@ for fs in legal:
     # break
 if not found:
     print >> sys.stderr, "Error: no such workspace"
+    sys.exit(-1)
+


### PR DESCRIPTION
I think that `ws_find` should return an error code when the workspace is not found so that it is easy to detect.