### PR TITLE
use python3

### DIFF
--- a/bin/ws_send_ical
+++ b/bin/ws_send_ical
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 """
     workspace++
@@ -45,11 +45,11 @@ from optparse import OptionParser
 from tempfile import mkstemp
 ### from datetime import datetime, date, time
 import smtplib
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEBase import MIMEBase
-from email.MIMEText import MIMEText
-from email.Utils import COMMASPACE, formatdate
-from email import Encoders
+from email.mime.multipart import MIMEMultipart
+from email.mime.base import MIMEBase
+from email.mime.text import MIMEText
+from email.utils import COMMASPACE, formatdate
+from email import encoders
 import datetime
 
 CRLF = "\r\n"


### PR DESCRIPTION
I think it is better to use explicit python3. (/usr/bin/python -> /usr/bin/python3)

Some syntax that is changed in python3 will be corrected if you merge this pull request.

I created this pull request separate from the first one.