### PR TITLE
fix empty version number output by using the version option at the release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,14 +88,21 @@ ENDIF (YAML)
 get_directory_property(LINKER_VAR LINK_DIRECTORIES)
 message(STATUS "LINKER_VAR: ${LINKER_VAR}")
 
-# git commit hash macro
-execute_process(
-  COMMAND git log -1 --format=%h
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_COMMIT_HASH
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-add_definitions("-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"")
+IF (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
+    SET (IS_GIT_REPOSITORY ON)
+    # git commit hash macro
+    execute_process(
+       COMMAND git log -1 --format=%h
+       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+       OUTPUT_VARIABLE WS_VERSION
+       OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+ELSE ()
+    SET (IS_GIT_REPOSITORY OFF)
+    # set to version number of the latest release
+    SET (WS_VERSION 1.0.0)
+ENDIF ()
+add_definitions("-DWS_VERSION=\"${WS_VERSION}\"")
 
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${workspace_BINARY_DIR}/bin)
 

--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -102,7 +102,7 @@ void commandline(po::variables_map &opt, string &name, int &duration, string &fi
     }
 
     if (opt.count("version")) {
-        cout << "workspace version " << GIT_COMMIT_HASH << endl;
+        cout << "workspace version " << WS_VERSION << endl;
         exit(1);
     }
 

--- a/src/ws_release.cpp
+++ b/src/ws_release.cpp
@@ -93,7 +93,7 @@ void commandline(po::variables_map &opt, string &name, int &duration,
     }
 
     if (opt.count("version")) {
-        cout << "workspace version " << GIT_COMMIT_HASH << endl;
+        cout << "workspace version " << WS_VERSION << endl;
         exit(1);
     }
 

--- a/src/ws_restore.cpp
+++ b/src/ws_restore.cpp
@@ -102,7 +102,7 @@ void commandline(po::variables_map &opt, string &name, string &target,
     }
 
     if (opt.count("version")) {
-        cout << "workspace version " << GIT_COMMIT_HASH << endl;
+        cout << "workspace version " << WS_VERSION << endl;
         exit(1);
     }
 


### PR DESCRIPTION
The git commit hash is printed as version number.
If the source is not a git repository then the version number output is empty.
The current commit checks if the subdirectory '.git' exists and acts appropriate the two situations.
The variable IS_GIT_REPOSITORY is set for further use that may be done in the future.