### PR TITLE
change the output from the version option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
-PROJECT(workspace)
-
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
+
+PROJECT(workspace)
+# set to version number of the latest release
+add_definitions("-DWS_VERSION=\"1.1.0\"")
 
 #workaround for old Redhat 6 cmake
 set(Boost_NO_BOOST_CMAKE ON)
@@ -89,20 +91,16 @@ get_directory_property(LINKER_VAR LINK_DIRECTORIES)
 message(STATUS "LINKER_VAR: ${LINKER_VAR}")
 
 IF (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
-    SET (IS_GIT_REPOSITORY ON)
+    add_definitions(-DIS_GIT_REPOSITORY)
     # git commit hash macro
     execute_process(
        COMMAND git log -1 --format=%h
        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-       OUTPUT_VARIABLE WS_VERSION
+       OUTPUT_VARIABLE GIT_COMMIT_HASH
        OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-ELSE ()
-    SET (IS_GIT_REPOSITORY OFF)
-    # set to version number of the latest release
-    SET (WS_VERSION 1.0.0)
+    add_definitions("-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"")
 ENDIF ()
-add_definitions("-DWS_VERSION=\"${WS_VERSION}\"")
 
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${workspace_BINARY_DIR}/bin)
 

--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -102,7 +102,12 @@ void commandline(po::variables_map &opt, string &name, int &duration, string &fi
     }
 
     if (opt.count("version")) {
+#ifdef IS_GIT_REPOSITORY
+        cout << "workspace build from git commit hash " << GIT_COMMIT_HASH
+             << " on top of release " << WS_VERSION << endl;
+#else
         cout << "workspace version " << WS_VERSION << endl;
+#endif
         exit(1);
     }
 

--- a/src/ws_release.cpp
+++ b/src/ws_release.cpp
@@ -93,7 +93,13 @@ void commandline(po::variables_map &opt, string &name, int &duration,
     }
 
     if (opt.count("version")) {
+#ifdef IS_GIT_REPOSITORY
+        cout << "workspace build from git commit hash " << GIT_COMMIT_HASH
+             << " on top of release " << WS_VERSION << endl;
+#else
         cout << "workspace version " << WS_VERSION << endl;
+#endif
+
         exit(1);
     }
 

--- a/src/ws_restore.cpp
+++ b/src/ws_restore.cpp
@@ -102,7 +102,12 @@ void commandline(po::variables_map &opt, string &name, string &target,
     }
 
     if (opt.count("version")) {
+#ifdef IS_GIT_REPOSITORY
+        cout << "workspace build from git commit hash " << GIT_COMMIT_HASH
+             << " on top of release " << WS_VERSION << endl;
+#else
         cout << "workspace version " << WS_VERSION << endl;
+#endif
         exit(1);
     }
 


### PR DESCRIPTION
The output from the version option by a build form the git sources will than look like:

- $ ./bin/ws_allocate -V
workspace build from git commit hash 4c04243 on top of release 1.1.0

The version definition is more on the top of the file `CMakeLists.txt` and is so easier to increase before you publish a new release.


This means that this definition goes to line 4

- add_definitions("-DWS_VERSION=\"1.1.0\"")

and needed to be increased appropriate to each release version.