### PR TITLE
Testing: Improve portablity

### DIFF
--- a/testing/scripts/cleanup_tests.sh
+++ b/testing/scripts/cleanup_tests.sh
@@ -4,9 +4,9 @@
 echo cleaning tmp
 rm -rf /tmp/ws
 echo removing users and groups
-deluser usera
-deluser userb
-deluser userc
-delgroup groupa
-delgroup groupb
-delgroup groupc
+userdel usera
+userdel userb
+userdel userc
+groupdel groupa
+groupdel groupb
+groupdel groupc

--- a/testing/scripts/prepare_tests.sh
+++ b/testing/scripts/prepare_tests.sh
@@ -7,13 +7,14 @@ rm -rf /tmp/ws
 echo "copying ws.conf"
 cp input/ws.conf.1 /etc/ws.conf
 echo "creating users and groups"
-addgroup groupa
-addgroup groupb
-addgroup groupc
-adduser --quiet --gecos "" --disabled-password useradmin
-adduser --quiet --gecos "" --ingroup groupa --disabled-password usera
-adduser --quiet --gecos "" --ingroup groupb --disabled-password userb
-adduser --quiet --gecos "" --ingroup groupc --disabled-password userc
+
+# Create user and groups in a portable way
+groupadd groupa
+groupadd groupb
+groupadd groupc
+useradd --groups groupa usera
+useradd --groups groupb userb
+useradd --groups groupc userc
 usermod -a -G groupa userc
 
 echo create workspaces etc


### PR DESCRIPTION
The commands useradd, groupadd, userdel and groupdel should be available on every unix system, while adduser and co are not.