### PR TITLE
prevent to use -m without -r

### DIFF
--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -161,6 +161,12 @@ void commandline(po::variables_map &opt, string &name, int &duration, string &fi
                 }
             }
         }
+    } else {
+        // check if mail address was set with -m but not -r
+        if(opt.count("mailaddress")) {
+            cerr << "Error: You can't use the mailaddress (-m) without the reminder (-r) option." << endl;
+            exit(1);
+        }
     }
 
     // validate workspace name against nasty characters    


### PR DESCRIPTION
This should protect the user to specify this email address without the option -r. Otherwise he may think he get an email but there will no email be send.