### PR TITLE
Revert "prevent to use -m without -r"

### DIFF
--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -161,12 +161,6 @@ void commandline(po::variables_map &opt, string &name, int &duration, string &fi
                 cerr << "Info: reminder email will be sent to local user account" << endl;
             }
         }
-    } else {
-        // check if mail address was set with -m but not -r
-        if(opt.count("mailaddress")) {
-            cerr << "Error: You can't use the mailaddress (-m) without the reminder (-r) option." << endl;
-            exit(1);
-        }
     }
 
     // validate workspace name against nasty characters    


### PR DESCRIPTION
Reverts holgerBerger/hpc-workspace#48

This breaks a test, and I think it is not 100% correct, as I think one can add both reminder and mail address with a second call to ws_allocate with -x.
