### PR TITLE
Minor code improvement and cleanup

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <fstream>
 #include <string>
+#include <vector>
 #include <unistd.h>
 #include <grp.h>
 #include <sys/types.h>
@@ -51,11 +52,6 @@ typedef int cap_value_t;
 const int CAP_DAC_OVERRIDE = 0;
 const int CAP_CHOWN = 1;
 #endif
-
-// C++ stuff
-#include <iostream>
-#include <string>
-#include <vector>
 
 // YAML
 #include <yaml-cpp/yaml.h>

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -107,16 +107,11 @@ Workspace::Workspace(const whichclient clientcode, const po::variables_map _opt,
     drop_cap(CAP_DAC_OVERRIDE, CAP_CHOWN, db_uid);
     // read private config
     raise_cap(CAP_DAC_OVERRIDE);
-
-
-    // read private config
-    raise_cap(CAP_DAC_OVERRIDE);
     try {
         userconfig = YAML::LoadFile("/etc/ws_private.conf");
     } catch (const YAML::BadFile&) {
         // we do not care
     }
-
     // lower again, nothing needed
     lower_cap(CAP_DAC_OVERRIDE, db_uid);
 

--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -95,8 +95,9 @@ Workspace::Workspace(const whichclient clientcode, const po::variables_map _opt,
     // read config
     try {
         config = YAML::LoadFile("/etc/ws.conf");
-    } catch (YAML::BadFile) {
-        cerr << "Error: no config file!" << endl;
+    } catch (const YAML::BadFile& e) {
+        cerr << "Error: Could not read config file!" << endl;
+        cerr << e.what() << endl;
         exit(-1);
     }
     db_uid = config["dbuid"].as<int>();
@@ -112,7 +113,7 @@ Workspace::Workspace(const whichclient clientcode, const po::variables_map _opt,
     raise_cap(CAP_DAC_OVERRIDE);
     try {
         userconfig = YAML::LoadFile("/etc/ws_private.conf");
-    } catch (YAML::BadFile) {
+    } catch (const YAML::BadFile&) {
         // we do not care
     }
 

--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -209,11 +209,7 @@ int main(int argc, char **argv) {
         exit(-1);
     }
 
-    try {
-    	reminder = config["reminderdefault"].as<int>();
-    } catch (YAML::BadConversion) {
-	reminder = 0;
-    }
+    reminder = config["reminderdefault"].as<int>(0);
 
 
     // check commandline, get flags which are used to create ws object or for workspace allocation

--- a/src/ws_allocate.cpp
+++ b/src/ws_allocate.cpp
@@ -204,8 +204,9 @@ int main(int argc, char **argv) {
     YAML::Node config;
     try {
         config = YAML::LoadFile("/etc/ws.conf");
-    } catch (YAML::BadFile) {
-        cerr << "Error: no config file!" << endl;
+    } catch (const YAML::BadFile& e) {
+        cerr << "Error: Could not read config file!" << endl;
+        cerr << e.what() << endl;
         exit(-1);
     }
 

--- a/src/ws_restore.cpp
+++ b/src/ws_restore.cpp
@@ -172,8 +172,9 @@ std::vector<string> get_valid_fslist() {
   // read config
   try {
       config = YAML::LoadFile("/etc/ws.conf");
-  } catch (YAML::BadFile) {
-      cerr << "Error: no config file!" << endl;
+  } catch (const YAML::BadFile& e) {
+      cerr << "Error: Could not read config file!" << endl;
+      cerr << e.what() << endl;
       exit(-1);
   }
 
@@ -255,8 +256,9 @@ vector<string> getRestorable(string filesystem, string username)
     // read config
     try {
         config = YAML::LoadFile("/etc/ws.conf");
-    } catch (YAML::BadFile) {
-        cerr << "Error: no config file!" << endl;
+    } catch (const YAML::BadFile& e) {
+        cerr << "Error: Could not read config file!" << endl;
+        cerr << e.what() << endl;
         exit(-1);
     }
 

--- a/src/wsdb.cpp
+++ b/src/wsdb.cpp
@@ -173,7 +173,7 @@ void WsDB::read_dbfile()
 		// lack the comment field, and this falls through into old path
         comment = entry["comment"].as<string>("");
 		// FIXME group missing here?
-    } catch (YAML::BadSubscript) {
+    } catch (const YAML::BadSubscript&) {
         // fallback to old db format, python version
         ifstream entry (dbfilename.c_str());
         entry >> expiration;

--- a/src/wsdb.cpp
+++ b/src/wsdb.cpp
@@ -169,13 +169,9 @@ void WsDB::read_dbfile()
         acctcode = entry["acctcode"].as<string>();
         reminder = entry["reminder"].as<int>();
         mailaddress = entry["mailaddress"].as<string>();
-		// this is needed as DBs before created before b7aa2e64b63e616fece9a23f76807dabcd12f815 
+		// DBs created before b7aa2e64b63e616fece9a23f76807dabcd12f815
 		// lack the comment field, and this falls through into old path
-		try {
-			comment = entry["comment"].as<string>();
-		} catch (YAML::TypedBadConversion<std::string>) {
-			comment = "";
-		}
+        comment = entry["comment"].as<string>("");
 		// FIXME group missing here?
     } catch (YAML::BadSubscript) {
         // fallback to old db format, python version


### PR DESCRIPTION
This series of commits includes
- Removing duplicate headers
- make use of YAML::as default values instead of current try catch semantics
- Fixes compiler warnings related to E.15 cpp core guidelines
- removes duplicate function invocation

