### PR TITLE
Avoid possible Null-Pointer dereference

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -967,6 +967,7 @@ std::vector<string> Workspace::get_valid_fslist() {
   grp=getgrgid(getegid());
   if(grp==NULL) {
        cerr << "Error: user has no group anymore!" << endl;
+       exit(-1);
   }
   primarygroup=string(grp->gr_name);
 

--- a/src/ws_restore.cpp
+++ b/src/ws_restore.cpp
@@ -216,7 +216,8 @@ std::vector<string> get_valid_fslist() {
   // get current group
   grp=getgrgid(getegid());
   if(grp==NULL) {
-       cerr << "Error: user has no group anymore!" << endl;
+      cerr << "Error: user has no group anymore!" << endl;
+      exit(-1);
   }
   primarygroup=string(grp->gr_name);
 


### PR DESCRIPTION
Hi,

this just adds, two `exit` calls to avoid a possible Null-pointer de-reference.