### PR TITLE
Fix ws_extend error when called without arguments

### DIFF
--- a/bin/ws_extend
+++ b/bin/ws_extend
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ "$#" -eq 2 ]
 then

--- a/bin/ws_extend
+++ b/bin/ws_extend
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-if [ $# -eq 2 ]
+if [ "$#" -eq 2 ]
 then
-    ws_allocate -x $1 $2
+    ws_allocate -x "$1" "$2"
     exit $?
 else
-    if [ $# -eq 4 -a $1 = "-F" ]
+    if [ "$#" -eq 4 -a "$1" = "-F" ]
     then
-    	ws_allocate -x $1 $2 $3 $4
+        ws_allocate -x "$1" "$2" "$3" "$4"
         exit $?
     else
         echo "Usage: ws_extend [-F filesystem] workspace days"


### PR DESCRIPTION
This is a fix for #63

* The ws_extend script was lacking proper quotation of arguments.
* Also changed interpreter from bash to pure shell as there is no need.