### PR TITLE
Fix wrong primary group assignment in Workspace::validate

### DIFF
--- a/src/ws.cpp
+++ b/src/ws.cpp
@@ -516,7 +516,7 @@ void Workspace::validate(const whichclient wc, YAML::Node &config, YAML::Node &u
 		}
     }
     // get current group
-    grp=getgrgid(getegid());
+    grp=getgrgid(getgid());
     if (grp==NULL) {
         cerr << "Error: user has no group anymore!" << endl;
         exit(-1);


### PR DESCRIPTION
* Use real group id instead of effective one as executables may be installed owned by group root have setgid attribute set.