### PR TITLE
Add -std=c++11 to CXX flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ add_definitions("-DWS_VERSION=\"1.3.4\"")
 #workaround for old Redhat 6 cmake
 set(Boost_NO_BOOST_CMAKE ON)
 
-SET(CMAKE_CXX_FLAGS "-Wall -g")
+SET(CMAKE_CXX_FLAGS "-Wall -g -std=c++11")
 
 OPTION(STATIC "static linking" FALSE)
 IF (STATIC)


### PR DESCRIPTION
Since there is some C++ code using `auto`, we need to compile using C++11.