### PR TITLE
Fix bash_completion for ws_restore

### DIFF
--- a/contribs/completion/ws_tools.sh
+++ b/contribs/completion/ws_tools.sh
@@ -40,7 +40,7 @@ function _ws_workspace_list() {
 }
 
 function _ws_restore_list() {
-    local restore_targets="$(ws_restore -l -b)"
+    local restore_targets="$(ws_restore -l -b | grep -E -v ":$")"
     printf "%s" "$restore_targets"
 }
 


### PR DESCRIPTION
The bash_completion for ws_restore displayed beside the names of
recoverable workspaces also file system names. This was caused, by the
helper function _ws_restore_list including filesystem headings from
the output of `ws_restore -l -b`.
Fixed for now by filtering out entries ending with a colon.

Signed-off-by: Christoph Niethammer <niethammer@hlrs.de>