### PR TITLE
Improve cmake compiler/linker flag handling for build targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ set(Boost_NO_BOOST_CMAKE ON)
 message(STATUS "build type: " ${CMAKE_BUILD_TYPE})
 message(STATUS "use cmake -DCMAKE_BUILD_TYPE=debug for debug build")
 
-SET(CMAKE_CXX_FLAGS "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++11 -Os")
-SET(CMAKE_CXX_FLAGS_DEBUG "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++11 -g -Os")
-SET(CMAKE_CXX_FLAGS_RELEASE "-Wall -Wno-deprecated-declarations -Wno-unused-variable -Wno-effc++ -std=c++11 -Os")
+add_compile_options(-Wall -std=c++11)
+add_link_options($<$<CONFIG:Release>:-s>)
+add_link_options($<$<CONFIG:MinSizeRel>:-s>)
 
 OPTION(STATIC "static linking" FALSE)
 IF (STATIC)
@@ -128,8 +128,6 @@ ENDIF ()
 
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${workspace_BINARY_DIR}/bin)
 
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 
 ADD_EXECUTABLE(ws_allocate ${workspace_SOURCE_DIR}/src/ws_allocate.cpp 
 							 ${workspace_SOURCE_DIR}/src/ws.cpp 


### PR DESCRIPTION
The compiler options did not fit the expectations from the default cmake build types and could not be modified via environment variables. Also some of the used compiler options were gcc specific. The problem came from the fixed assignments to the CMAKE_*_FLAGS_* variables.

- Replaced the fixed assignments with corresponding add_*_options for compiler and linker options that allow to use, e.g., the CXXFLAGS environment variable, to pass additional options.
- Removed (gcc-specific) compiler options for suppression of some warnings
- Used cmake generator expressions to add "Release"/"MinSizeRel" specific options
- Pass the symbol striping option to the linker instead of to the compiler