### PR TITLE
Add an option to chose space by most free bytes

### DIFF
--- a/admin-guide.md
+++ b/admin-guide.md
@@ -286,7 +286,9 @@ or fileservers or metadata domains like DNE in Lustre.
 
 ### `spaceselection`
 
-can be `random` which is default, or `uid` or `gid` to select space based on modulo operation with uid or gid.
+can be `random` which is default, or `uid` or `gid` to select space based on
+modulo operation with uid or gid, or `mostspace` to choose the filesystem with
+most available space
 
 #### `deleted`
 

--- a/sbin/ws_validate_config
+++ b/sbin/ws_validate_config
@@ -143,7 +143,7 @@ for ws in workspaces:
         sys.exit(1)
     try:
         print(" spaceselection :", config["workspaces"][ws]["spaceselection"])
-        if config["workspaces"][ws]["spaceselection"] not in ["random", "uid", "gid"]:
+        if config["workspaces"][ws]["spaceselection"] not in ["random", "uid", "gid", "mostspace"]:
             print(" WARNING: unkown spaceselection, default `random` will be used")
     except:
         pass

--- a/ws.conf_full_sample
+++ b/ws.conf_full_sample
@@ -18,7 +18,7 @@ workspaces:                     # now the list of the workspaces
   lustre:                       # name of workspace as shown with ws_list -l
     keeptime: 1                 # mandatory, time in days to keep workspaces after they expired
     spaces: [/lustre1/ws, /lustre2/ws]  # mandatory, list of directories
-    spaceselection: random      # "random" (default), "uid" (uid%#spaces), "gid" (gid%#spaces)
+    spaceselection: random      # "random" (default), "uid" (uid%#spaces), "gid" (gid%#spaces), "mostspace"
     deleted: .removed           # mandatory, will be appended to spaces and database 
                                 # to move deleted files to
     database: /lustre-db        # mandatory, the DB directory, this is where DB files will end


### PR DESCRIPTION
When adding a new space to an existing workspace, the existing algorithms will still try to split allocations evenly. Adding this option gives the ability to prefer the space with the most available room instead.